### PR TITLE
added login with did

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import './App.css';
-import { Routes, Route, HashRouter } from "react-router-dom";
+import { Routes, Route, HashRouter, Navigate } from "react-router-dom";
 import Connect from './pages/connect/Connect';
 import SelectProfile from './pages/select-profile/SelectProfile';
 import Claimer from './pages/claimer/Claimer';
@@ -28,6 +28,7 @@ function App() {
         <Route path="/attester/ctypes/create" element={<AttesterCtypeCreate />}> </Route>
         <Route path="/attester/requests" element={<AttesterRequests />}> </Route>
         <Route path="/attester/requests/:id" element={<AttesterRequestDetail />}> </Route>
+        <Route path='/.well-known/did-configuration.json' element={ <Navigate to="/didConfiguration.json" /> }/>
       </Routes>
     </HashRouter>
     </div>

--- a/src/components/Topbar/Topbar.tsx
+++ b/src/components/Topbar/Topbar.tsx
@@ -1,12 +1,15 @@
 import useUser from '../../hooks/user';
+import { formatDid } from '../../utils/string';
 
 function Topbar() {
-  const { user, isAttester } = useUser();
+  const { user } = useUser();
   
   return (
     <div className='topbar'>
       <div className='topbar-content'>
-        {isAttester ? 'Attester: ' : 'Claimer: ' + user}
+        { user && 
+          (user.isAttester ? 'Attester: ' : 'Claimer: ') + 
+          formatDid(user ? user.did : '')}
       </div>
     </div>
   );

--- a/src/hooks/attester.ts
+++ b/src/hooks/attester.ts
@@ -38,7 +38,6 @@ export default function useAttester() {
       setTimeout(resolve, 500);
     });
     setLoading(false);
-    console.log('deleting id:', id, ' fromuser:', user);
     throw Error('not implemented');
   }
 

--- a/src/hooks/fetch.ts
+++ b/src/hooks/fetch.ts
@@ -1,0 +1,11 @@
+
+export default function useFetch () {
+  const appFetch = (url: string, opts?: any) => {
+    if (url.startsWith('/')) return fetch('http://localhost:8000' + url, opts)
+    else return fetch(url, opts);
+  }
+  return {
+    appFetch
+  }
+}
+

--- a/src/hooks/sporran.ts
+++ b/src/hooks/sporran.ts
@@ -1,58 +1,8 @@
 import { useState, useEffect } from 'react';
-import { ISporran } from '../interfaces/sporran';
+import useFetch from './fetch';
 
 export default function useSporran () {
-  const [ sporran, setSporran ] = useState<ISporran | null>(null);
-  const [ session, setSession ] = useState<any>(null);
-  const [ waiting, setWaiting ] = useState(false);
-
-  async function presentCredential() {
-    setWaiting(true);
-    if (!session) throw Error('startSession first');
-
-    const { sessionId } = session;
-    const result = await fetch(`https://someapi.com/api/verify?sessionId=${sessionId}`);
-    const message = await result.json();
-
-    session.listen(async (message: any) => {
-      await fetch('https://someapi.com/api/verify', {
-        method: 'POST',
-        headers: { ContentType: 'application/json' },
-        body: JSON.stringify({ sessionId, message }),
-      });
-
-      setWaiting(false);
-    });
-  
-    await session.send(message);
-  }
-
-  async function startSession() {
-    if(!sporran) return;
-    setWaiting(true);
-    const values = await fetch('/api/session');
-    if (!values.ok) throw Error(values.statusText);
-
-    const {
-      sessionId,
-      challenge,
-      dappName,
-      dAppEncryptionKeyUri,
-    } = await values.json();
-
-    const session = await sporran.startSession(dappName, dAppEncryptionKeyUri, challenge);
-    
-    const valid = await fetch('/api/session', { 
-      method: 'POST', 
-      headers: { ContentType: 'application/json' },
-      body: JSON.stringify({ ...session, sessionId }),
-    });
-
-    if (!valid.ok) throw Error(valid.statusText);
-
-    setWaiting(false);
-    setSession({ sessionId, ...session });
-  }
+  const [ sporran, setSporran ] = useState<any>(null);
 
   useEffect(() => {
     const inState = !!sporran;
@@ -71,13 +21,9 @@ export default function useSporran () {
         } 
       })
     }
-  }, []);
+  });
 
   return { 
-    sporran, 
-    session, 
-    waiting, 
-    startSession, 
-    presentCredential,
+    sporran
   }
 }

--- a/src/interfaces/sporran.ts
+++ b/src/interfaces/sporran.ts
@@ -1,9 +1,0 @@
-
-export interface ISporran {
-  name: string;
-  signExtrinsicWithDid: (arg: any) => Promise<any>,
-  signWithDid: (arg: any) => Promise<any>,
-  specVersion: string,
-  startSession: (dappName: any, dAppEncryptionKeyUri: any, challenge: any) => Promise<any>,
-  version: string,
-}

--- a/src/interfaces/user.ts
+++ b/src/interfaces/user.ts
@@ -1,0 +1,8 @@
+import { DidResourceUri } from "@kiltprotocol/types";
+
+export interface IUser {
+  did: string;
+  signature: string;
+  didKeyUri: DidResourceUri;
+  isAttester: boolean;
+}

--- a/src/pages/connect/Connect.tsx
+++ b/src/pages/connect/Connect.tsx
@@ -1,16 +1,25 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import useUser from '../../hooks/user';
 
 function Connect() {
   const navigate = useNavigate();
+  const [did, setDid] = useState<string>('');
+  
+  const { login } = useUser();
+  const { user } = useUser();
   
   const connect = async () => {
-    //await login();
-    navigate('/select-profile');
+    await login(did);
+    if(!user) return;
+    if (user.isAttester) navigate('/select-profile');
+    else navigate('/claimer');
   }
 
   return (
     <div className='wrapper'>
-      <div className='center'>
+      <div className='center column'>
+        <input type="text" value={did} placeholder={'did'} onChange={(e) => setDid(e.target.value)} />
         <button className='connect-btn' onClick={connect}>
           Connect
         </button>

--- a/src/pages/select-profile/SelectProfile.tsx
+++ b/src/pages/select-profile/SelectProfile.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import EmojiButton from '../../components/EmojiButton/EmojiButton';
 import useUser from '../../hooks/user';
+import { formatDid } from '../../utils/string';
 
 function SelectProfile() {
   const navigate = useNavigate();
@@ -14,7 +15,7 @@ function SelectProfile() {
       <div className='center'>
         <div className='title' >
           <span>
-            Hi {user} <br />
+            Hi {formatDid(user ? user.did : '')}<br />
             Select your profile
           </span>
         </div>

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,0 +1,2 @@
+export const formatDid = (did: string) => 
+  did.substring(0, 12) + '...' + did.substring(did.length - 5, did.length - 1)


### PR DESCRIPTION
Login process now works using the user did, after successful login, the app saves the user information in localStorage.

If the user is already an attester then redirects to the `select-profile `path, if not it redirects to `claimer` path